### PR TITLE
Migrating from master and slave lingo

### DIFF
--- a/dnh/test/__init__.py
+++ b/dnh/test/__init__.py
@@ -11,7 +11,7 @@ class DnhTestCase(unittest.TestCase):
                               group=dnh_consumer.CFG_GRP)
         cfg.CONF.set_override('servers', ['host1:4242', 'host2'],
                               group=nsd4.CFG_GRP)
-        cfg.CONF.set_override('pattern', 'slave',
+        cfg.CONF.set_override('pattern', 'subordinate',
                               group=nsd4.CFG_GRP)
 
     def get_create_notification(self):


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.